### PR TITLE
Add Github workflow for JDK Images Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,121 @@
+name: Build & publish eXo JDK images
+on:
+  schedule:
+    - cron:  '0 22 * * 6' # Every Saturday at 9 PM UTC
+  workflow_dispatch:
+
+jobs:
+  build-jdk-images:
+    name: "Build JDK Images"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # JDK 8
+          ## Ubuntu 22.04
+          - imageTag: 8
+            context: openjdk-8/ubuntu/22.04
+          - imageTag: 8-ubuntu
+            context: openjdk-8/ubuntu/22.04
+          - imageTag: 8-ubuntu-22
+            context: openjdk-8/ubuntu/22.04
+          - imageTag: 8-ubuntu-2204
+            context: openjdk-8/ubuntu/22.04
+          - imageTag: openjdk-8-ubuntu-2204
+            context: openjdk-8/ubuntu/22.04
+          ## Ubuntu 20.04
+          - imageTag: 8-ubuntu-20
+            context: openjdk-8/ubuntu/20.04
+          - imageTag: 8-ubuntu-2004
+            context: openjdk-8/ubuntu/20.04
+          - imageTag: openjdk-8-ubuntu-2004
+            context: openjdk-8/ubuntu/20.04
+          # JDK 11
+          ## Ubuntu 22.04
+          - imageTag: 11
+            context: openjdk-11/ubuntu/22.04
+          - imageTag: 11-ubuntu
+            context: openjdk-11/ubuntu/22.04
+          - imageTag: 11-ubuntu-22
+            context: openjdk-11/ubuntu/22.04
+          - imageTag: 11-ubuntu-2204
+            context: openjdk-11/ubuntu/22.04
+          - imageTag: 11-ubuntu-2204
+            context: openjdk-11/ubuntu/22.04
+          - imageTag: openjdk-11-ubuntu-2204
+            context: openjdk-11/ubuntu/22.04
+          ## Ubuntu 20.04
+          - imageTag: 11-ubuntu-20
+            context: openjdk-11/ubuntu/20.04
+          - imageTag: 11-ubuntu-2004
+            context: openjdk-11/ubuntu/20.04
+          - imageTag: 11-ubuntu-2004
+            context: openjdk-11/ubuntu/20.04
+          - imageTag: openjdk-11-ubuntu-2004
+            context: openjdk-11/ubuntu/20.04
+          # JDK 14
+          ## Ubuntu 22.04
+          - imageTag: 14
+            context: openjdk-14/ubuntu/22.04
+          - imageTag: 14-ubuntu
+            context: openjdk-14/ubuntu/22.04
+          - imageTag: 14-ubuntu-22
+            context: openjdk-14/ubuntu/22.04
+          - imageTag: 14-ubuntu-2204
+            context: openjdk-14/ubuntu/22.04
+          - imageTag: 14-ubuntu-2204
+            context: openjdk-14/ubuntu/22.04
+          - imageTag: openjdk-14-ubuntu-2204
+            context: openjdk-14/ubuntu/22.04
+          ## Ubuntu 20.04
+          - imageTag: 14-ubuntu-2004
+            context: openjdk-14/ubuntu/20.04
+          - imageTag: 14-ubuntu-20
+            context: openjdk-14/ubuntu/20.04
+          - imageTag: 14-ubuntu-2004
+            context: openjdk-14/ubuntu/20.04
+          - imageTag: openjdk-14-ubuntu-2004
+            context: openjdk-14/ubuntu/20.04
+          # JDK 17
+          ## Ubuntu 22.04
+          - imageTag: 17
+            context: openjdk-17/ubuntu/22.04
+          - imageTag: 17-ubuntu
+            context: openjdk-17/ubuntu/22.04
+          - imageTag: 17-ubuntu-2204
+            context: openjdk-17/ubuntu/22.04
+          - imageTag: 17-ubuntu-2204
+            context: openjdk-17/ubuntu/22.04
+          - imageTag: openjdk-17-ubuntu-2204
+            context: openjdk-17/ubuntu/22.04
+          ## Ubuntu 20.04
+          - imageTag: 17-ubuntu-2004
+            context: openjdk-17/ubuntu/20.04
+          - imageTag: 17-ubuntu-2004
+            context: openjdk-17/ubuntu/20.04
+          - imageTag: openjdk-17-ubuntu-2004
+            context: openjdk-17/ubuntu/20.04
+          # JDK 21
+          ## Ubuntu 22.04
+          - imageTag: 21
+            context: openjdk-21/ubuntu/22.04
+          - imageTag: 21-ubuntu
+            context: openjdk-21/ubuntu/22.04
+          - imageTag: 21-ubuntu-2204
+            context: openjdk-21/ubuntu/22.04
+          - imageTag: 21-ubuntu-2204
+            context: openjdk-21/ubuntu/22.04
+          - imageTag: openjdk-21-ubuntu-2204
+            context: openjdk-21/ubuntu/22.04
+          ### Latest
+          - imageTag: latest
+            context: openjdk-21/ubuntu/22.04
+
+    uses: exoplatform/swf-scripts/.github/workflows/buildDockerImage.yml@master
+    with:
+      dockerImage: "exoplatform/jdk"
+      dockerImageTag: ${{ matrix.imageTag }}
+      dockerFileContext: ${{ matrix.context }}
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build & publish eXo JDK images
 on:
   schedule:
-    - cron:  '0 22 * * 6' # Every Saturday at 9 PM UTC
+    - cron:  '0 22 * * 6' # Every Saturday at 10 PM UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Prior to this change, DockerHub autobuilds are so limited (16 slots available) and our CI Image is having more and more versions. Moreover DockerHub builds are too slow